### PR TITLE
Add Windows build support (v1.2.0)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
-.PHONY: build run clean deps setup install-deps
+.PHONY: build run clean deps setup install-deps build-windows build-linux build-all
 
+# Default build for current platform
 build:
 	go build -o nelko-print ./cmd/nelko-print
 
@@ -7,7 +8,7 @@ run: build
 	./nelko-print
 
 clean:
-	rm -f nelko-print
+	rm -f nelko-print nelko-print.exe
 
 deps:
 	go mod tidy
@@ -16,9 +17,31 @@ deps:
 setup:
 	./setup.sh
 
+# === Cross-compilation targets ===
+
+# Build for Windows (from Linux)
+build-windows:
+	GOOS=windows GOARCH=amd64 CGO_ENABLED=1 CC=x86_64-w64-mingw32-gcc \
+		go build -o nelko-print.exe ./cmd/nelko-print
+
+# Build for Linux explicitly
+build-linux:
+	GOOS=linux GOARCH=amd64 go build -o nelko-print ./cmd/nelko-print
+
+# Build for all platforms
+build-all: build-linux build-windows
+
+# === System dependency installation ===
+
 # Install system deps (Ubuntu/Zorin)
 install-deps:
 	sudo apt install -y libgl1-mesa-dev xorg-dev bluez
+
+# Install cross-compilation tools for Windows builds
+install-cross-deps:
+	sudo apt install -y mingw-w64
+
+# === Bluetooth utilities ===
 
 # List paired Bluetooth devices
 list-bt:

--- a/cmd/nelko-print/main.go
+++ b/cmd/nelko-print/main.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	AppVersion = "1.1.0"
+	AppVersion = "1.2.0"
 	AppName    = "Nelko P21 Print"
 )
 

--- a/internal/printer/bluetooth.go
+++ b/internal/printer/bluetooth.go
@@ -1,258 +1,31 @@
 package printer
 
-import (
-	"bufio"
-	"context"
-	"errors"
-	"fmt"
-	"os"
-	"os/exec"
-	"path/filepath"
-	"strings"
-	"sync"
-	"time"
-)
+import "errors"
 
+// Common errors
 var (
 	ErrNoDevicesFound     = errors.New("no paired Bluetooth devices found")
 	ErrRFCOMMFailed       = errors.New("failed to establish RFCOMM connection")
 	ErrPrivilegeRequired  = errors.New("root privileges required for RFCOMM")
 	ErrConnectionCanceled = errors.New("connection canceled")
+	ErrNotSupported       = errors.New("operation not supported on this platform")
 )
 
 // BluetoothDevice represents a paired Bluetooth device
 type BluetoothDevice struct {
 	Name string
-	MAC  string
+	MAC  string // MAC address on Linux, or COM port on Windows
 }
 
-// RFCOMMConnection manages an RFCOMM connection process
-type RFCOMMConnection struct {
+// BluetoothConnection manages a Bluetooth serial connection
+// Implementation is platform-specific
+type BluetoothConnection struct {
 	DevicePath string
 	MAC        string
-	cmd        *exec.Cmd
-	cancel     context.CancelFunc
-	mu         sync.Mutex
+	platform   interface{} // Platform-specific data
 }
 
-// ListPairedBluetoothDevices returns all paired Bluetooth devices
-func ListPairedBluetoothDevices() ([]BluetoothDevice, error) {
-	out, err := exec.Command("bluetoothctl", "devices", "Paired").Output()
-	if err != nil {
-		return nil, fmt.Errorf("failed to list paired devices: %w", err)
-	}
-
-	var devices []BluetoothDevice
-	lines := strings.Split(string(out), "\n")
-	for _, line := range lines {
-		line = strings.TrimSpace(line)
-		if !strings.HasPrefix(line, "Device ") {
-			continue
-		}
-		// Format: "Device XX:XX:XX:XX:XX:XX DeviceName"
-		parts := strings.SplitN(strings.TrimPrefix(line, "Device "), " ", 2)
-		if len(parts) == 2 {
-			devices = append(devices, BluetoothDevice{
-				MAC:  parts[0],
-				Name: parts[1],
-			})
-		}
-	}
-
-	return devices, nil
-}
-
-// FindAvailableRFCOMMDevice finds an unused /dev/rfcommN device number
-func FindAvailableRFCOMMDevice() (string, int, error) {
-	for i := 0; i < 10; i++ {
-		devPath := fmt.Sprintf("/dev/rfcomm%d", i)
-		// Check if device is currently bound
-		out, _ := exec.Command("rfcomm", "show", devPath).Output()
-		if len(out) == 0 || strings.Contains(string(out), "No such device") {
-			return devPath, i, nil
-		}
-	}
-	return "", -1, errors.New("no available RFCOMM device slots")
-}
-
-// CheckRFCOMMInstalled verifies rfcomm binary is available
-func CheckRFCOMMInstalled() error {
-	_, err := exec.LookPath("rfcomm")
-	if err != nil {
-		return errors.New("rfcomm not found - install with: sudo apt install bluez")
-	}
-	return nil
-}
-
-// CheckPrivilegeHelper checks which privilege escalation method is available
-func CheckPrivilegeHelper() string {
-	// Check for pkexec (PolicyKit - works with GUI)
-	if _, err := exec.LookPath("pkexec"); err == nil {
-		return "pkexec"
-	}
-	// Check for sudo
-	if _, err := exec.LookPath("sudo"); err == nil {
-		return "sudo"
-	}
-	return ""
-}
-
-// EstablishRFCOMM creates an RFCOMM connection to the given MAC address
-// This runs rfcomm connect in the background and returns when the device is ready
-func EstablishRFCOMM(mac string, channel int, statusCallback func(string)) (*RFCOMMConnection, error) {
-	if err := CheckRFCOMMInstalled(); err != nil {
-		return nil, err
-	}
-
-	devPath, devNum, err := FindAvailableRFCOMMDevice()
-	if err != nil {
-		return nil, err
-	}
-
-	helper := CheckPrivilegeHelper()
-	if helper == "" {
-		return nil, ErrPrivilegeRequired
-	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	conn := &RFCOMMConnection{
-		DevicePath: devPath,
-		MAC:        mac,
-		cancel:     cancel,
-	}
-
-	// Build the command based on available privilege helper
-	var cmd *exec.Cmd
-	rfcommArgs := []string{"connect", fmt.Sprintf("/dev/rfcomm%d", devNum), mac, fmt.Sprintf("%d", channel)}
-
-	if helper == "pkexec" {
-		cmd = exec.CommandContext(ctx, "pkexec", append([]string{"rfcomm"}, rfcommArgs...)...)
-	} else {
-		cmd = exec.CommandContext(ctx, "sudo", append([]string{"-n", "rfcomm"}, rfcommArgs...)...)
-	}
-
-	conn.cmd = cmd
-
-	// Capture stderr for status messages
-	stderr, _ := cmd.StderrPipe()
-	stdout, _ := cmd.StdoutPipe()
-
-	if statusCallback != nil {
-		statusCallback(fmt.Sprintf("Connecting to %s...", mac))
-	}
-
-	if err := cmd.Start(); err != nil {
-		cancel()
-		return nil, fmt.Errorf("failed to start rfcomm: %w", err)
-	}
-
-	// Read output in background
-	go func() {
-		scanner := bufio.NewScanner(stdout)
-		for scanner.Scan() {
-			if statusCallback != nil {
-				statusCallback(scanner.Text())
-			}
-		}
-	}()
-	go func() {
-		scanner := bufio.NewScanner(stderr)
-		for scanner.Scan() {
-			if statusCallback != nil {
-				statusCallback(scanner.Text())
-			}
-		}
-	}()
-
-	// Wait for device to appear
-	deadline := time.Now().Add(15 * time.Second)
-	for time.Now().Before(deadline) {
-		select {
-		case <-ctx.Done():
-			return nil, ErrConnectionCanceled
-		default:
-		}
-
-		if _, err := os.Stat(devPath); err == nil {
-			// Device exists, give it a moment to be ready
-			time.Sleep(500 * time.Millisecond)
-			if statusCallback != nil {
-				statusCallback(fmt.Sprintf("Connected: %s", devPath))
-			}
-			return conn, nil
-		}
-		time.Sleep(500 * time.Millisecond)
-	}
-
-	// Timeout - kill the process
-	conn.Close()
-	return nil, fmt.Errorf("timeout waiting for %s to appear", devPath)
-}
-
-// Close terminates the RFCOMM connection
-func (c *RFCOMMConnection) Close() error {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	if c.cancel != nil {
-		c.cancel()
-	}
-
-	// Also explicitly release the device
-	if c.DevicePath != "" {
-		// Try to release - may need privileges
-		helper := CheckPrivilegeHelper()
-		if helper == "pkexec" {
-			exec.Command("pkexec", "rfcomm", "release", c.DevicePath).Run()
-		} else if helper == "sudo" {
-			exec.Command("sudo", "-n", "rfcomm", "release", c.DevicePath).Run()
-		}
-	}
-
-	if c.cmd != nil && c.cmd.Process != nil {
-		c.cmd.Process.Kill()
-		c.cmd.Wait()
-	}
-
-	return nil
-}
-
-// IsDeviceReady checks if the RFCOMM device is still available
-func (c *RFCOMMConnection) IsDeviceReady() bool {
-	if c.DevicePath == "" {
-		return false
-	}
-	_, err := os.Stat(c.DevicePath)
-	return err == nil
-}
-
-// GetExistingRFCOMMConnections returns currently active RFCOMM connections
-func GetExistingRFCOMMConnections() ([]string, error) {
-	out, err := exec.Command("rfcomm", "-a").Output()
-	if err != nil {
-		// rfcomm -a might fail if no connections, check for devices directly
-		var devices []string
-		for i := 0; i < 10; i++ {
-			devPath := fmt.Sprintf("/dev/rfcomm%d", i)
-			if _, err := os.Stat(devPath); err == nil {
-				devices = append(devices, devPath)
-			}
-		}
-		return devices, nil
-	}
-
-	var devices []string
-	lines := strings.Split(string(out), "\n")
-	for _, line := range lines {
-		if strings.Contains(line, "rfcomm") {
-			// Extract device path
-			parts := strings.Fields(line)
-			if len(parts) > 0 {
-				devName := strings.TrimSuffix(parts[0], ":")
-				devices = append(devices, filepath.Join("/dev", devName))
-			}
-		}
-	}
-
-	return devices, nil
+// IsDeviceReady checks if the connection is still valid
+func (c *BluetoothConnection) IsDeviceReady() bool {
+	return c != nil && c.DevicePath != ""
 }

--- a/internal/printer/bluetooth_linux.go
+++ b/internal/printer/bluetooth_linux.go
@@ -1,0 +1,265 @@
+//go:build linux
+
+package printer
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+// RFCOMMConnection manages an RFCOMM connection process (Linux-specific)
+type RFCOMMConnection struct {
+	DevicePath string
+	MAC        string
+	cmd        *exec.Cmd
+	cancel     context.CancelFunc
+	mu         sync.Mutex
+}
+
+// ListPairedBluetoothDevices returns all paired Bluetooth devices
+func ListPairedBluetoothDevices() ([]BluetoothDevice, error) {
+	out, err := exec.Command("bluetoothctl", "devices", "Paired").Output()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list paired devices: %w", err)
+	}
+
+	var devices []BluetoothDevice
+	lines := strings.Split(string(out), "\n")
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "Device ") {
+			continue
+		}
+		// Format: "Device XX:XX:XX:XX:XX:XX DeviceName"
+		parts := strings.SplitN(strings.TrimPrefix(line, "Device "), " ", 2)
+		if len(parts) == 2 {
+			devices = append(devices, BluetoothDevice{
+				MAC:  parts[0],
+				Name: parts[1],
+			})
+		}
+	}
+
+	return devices, nil
+}
+
+// FindAvailableRFCOMMDevice finds an unused /dev/rfcommN device number
+func FindAvailableRFCOMMDevice() (string, int, error) {
+	for i := 0; i < 10; i++ {
+		devPath := fmt.Sprintf("/dev/rfcomm%d", i)
+		// Check if device is currently bound
+		out, _ := exec.Command("rfcomm", "show", devPath).Output()
+		if len(out) == 0 || strings.Contains(string(out), "No such device") {
+			return devPath, i, nil
+		}
+	}
+	return "", -1, fmt.Errorf("no available RFCOMM device slots")
+}
+
+// CheckRFCOMMInstalled verifies rfcomm binary is available
+func CheckRFCOMMInstalled() error {
+	_, err := exec.LookPath("rfcomm")
+	if err != nil {
+		return fmt.Errorf("rfcomm not found - install with: sudo apt install bluez")
+	}
+	return nil
+}
+
+// CheckPrivilegeHelper checks which privilege escalation method is available
+func CheckPrivilegeHelper() string {
+	// Check for pkexec (PolicyKit - works with GUI)
+	if _, err := exec.LookPath("pkexec"); err == nil {
+		return "pkexec"
+	}
+	// Check for sudo
+	if _, err := exec.LookPath("sudo"); err == nil {
+		return "sudo"
+	}
+	return ""
+}
+
+// EstablishRFCOMM creates an RFCOMM connection to the given MAC address
+// This runs rfcomm connect in the background and returns when the device is ready
+func EstablishRFCOMM(mac string, channel int, statusCallback func(string)) (*RFCOMMConnection, error) {
+	if err := CheckRFCOMMInstalled(); err != nil {
+		return nil, err
+	}
+
+	devPath, devNum, err := FindAvailableRFCOMMDevice()
+	if err != nil {
+		return nil, err
+	}
+
+	helper := CheckPrivilegeHelper()
+	if helper == "" {
+		return nil, ErrPrivilegeRequired
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	conn := &RFCOMMConnection{
+		DevicePath: devPath,
+		MAC:        mac,
+		cancel:     cancel,
+	}
+
+	// Build the command based on available privilege helper
+	var cmd *exec.Cmd
+	rfcommArgs := []string{"connect", fmt.Sprintf("/dev/rfcomm%d", devNum), mac, fmt.Sprintf("%d", channel)}
+
+	if helper == "pkexec" {
+		cmd = exec.CommandContext(ctx, "pkexec", append([]string{"rfcomm"}, rfcommArgs...)...)
+	} else {
+		cmd = exec.CommandContext(ctx, "sudo", append([]string{"-n", "rfcomm"}, rfcommArgs...)...)
+	}
+
+	conn.cmd = cmd
+
+	// Capture stderr for status messages
+	stderr, _ := cmd.StderrPipe()
+	stdout, _ := cmd.StdoutPipe()
+
+	if statusCallback != nil {
+		statusCallback(fmt.Sprintf("Connecting to %s...", mac))
+	}
+
+	if err := cmd.Start(); err != nil {
+		cancel()
+		return nil, fmt.Errorf("failed to start rfcomm: %w", err)
+	}
+
+	// Read output in background
+	go func() {
+		scanner := bufio.NewScanner(stdout)
+		for scanner.Scan() {
+			if statusCallback != nil {
+				statusCallback(scanner.Text())
+			}
+		}
+	}()
+	go func() {
+		scanner := bufio.NewScanner(stderr)
+		for scanner.Scan() {
+			if statusCallback != nil {
+				statusCallback(scanner.Text())
+			}
+		}
+	}()
+
+	// Wait for device to appear
+	deadline := time.Now().Add(15 * time.Second)
+	for time.Now().Before(deadline) {
+		select {
+		case <-ctx.Done():
+			return nil, ErrConnectionCanceled
+		default:
+		}
+
+		if _, err := os.Stat(devPath); err == nil {
+			// Device exists, give it a moment to be ready
+			time.Sleep(500 * time.Millisecond)
+			if statusCallback != nil {
+				statusCallback(fmt.Sprintf("Connected: %s", devPath))
+			}
+			return conn, nil
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+
+	// Timeout - kill the process
+	conn.Close()
+	return nil, fmt.Errorf("timeout waiting for %s to appear", devPath)
+}
+
+// Close terminates the RFCOMM connection
+func (c *RFCOMMConnection) Close() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.cancel != nil {
+		c.cancel()
+	}
+
+	// Also explicitly release the device
+	if c.DevicePath != "" {
+		// Try to release - may need privileges
+		helper := CheckPrivilegeHelper()
+		if helper == "pkexec" {
+			exec.Command("pkexec", "rfcomm", "release", c.DevicePath).Run()
+		} else if helper == "sudo" {
+			exec.Command("sudo", "-n", "rfcomm", "release", c.DevicePath).Run()
+		}
+	}
+
+	if c.cmd != nil && c.cmd.Process != nil {
+		c.cmd.Process.Kill()
+		c.cmd.Wait()
+	}
+
+	return nil
+}
+
+// IsDeviceReady checks if the RFCOMM device is still available
+func (c *RFCOMMConnection) IsDeviceReady() bool {
+	if c.DevicePath == "" {
+		return false
+	}
+	_, err := os.Stat(c.DevicePath)
+	return err == nil
+}
+
+// GetExistingRFCOMMConnections returns currently active RFCOMM connections
+func GetExistingRFCOMMConnections() ([]string, error) {
+	out, err := exec.Command("rfcomm", "-a").Output()
+	if err != nil {
+		// rfcomm -a might fail if no connections, check for devices directly
+		var devices []string
+		for i := 0; i < 10; i++ {
+			devPath := fmt.Sprintf("/dev/rfcomm%d", i)
+			if _, err := os.Stat(devPath); err == nil {
+				devices = append(devices, devPath)
+			}
+		}
+		return devices, nil
+	}
+
+	var devices []string
+	lines := strings.Split(string(out), "\n")
+	for _, line := range lines {
+		if strings.Contains(line, "rfcomm") {
+			// Extract device path
+			parts := strings.Fields(line)
+			if len(parts) > 0 {
+				devName := strings.TrimSuffix(parts[0], ":")
+				devices = append(devices, filepath.Join("/dev", devName))
+			}
+		}
+	}
+
+	return devices, nil
+}
+
+// ListSerialPorts returns available serial ports (for manual connection)
+func ListSerialPorts() ([]string, error) {
+	var ports []string
+
+	// Check for rfcomm devices
+	rfcomm, _ := GetExistingRFCOMMConnections()
+	ports = append(ports, rfcomm...)
+
+	// Check common serial ports
+	commonPorts := []string{"/dev/ttyUSB0", "/dev/ttyUSB1", "/dev/ttyACM0", "/dev/ttyACM1"}
+	for _, p := range commonPorts {
+		if _, err := os.Stat(p); err == nil {
+			ports = append(ports, p)
+		}
+	}
+
+	return ports, nil
+}

--- a/internal/printer/bluetooth_windows.go
+++ b/internal/printer/bluetooth_windows.go
@@ -1,0 +1,181 @@
+//go:build windows
+
+package printer
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"golang.org/x/sys/windows/registry"
+)
+
+// RFCOMMConnection is a compatibility type for Windows
+// On Windows, we don't need to manage RFCOMM - COM ports are created automatically
+type RFCOMMConnection struct {
+	DevicePath string
+	MAC        string
+}
+
+// ListPairedBluetoothDevices returns Bluetooth COM ports on Windows
+// On Windows, paired BT SPP devices appear as COM ports automatically
+func ListPairedBluetoothDevices() ([]BluetoothDevice, error) {
+	var devices []BluetoothDevice
+
+	// On Windows, we list COM ports that are Bluetooth-related
+	// Check registry for Bluetooth COM ports
+	btPorts, err := getBluetoothCOMPorts()
+	if err == nil {
+		for name, port := range btPorts {
+			devices = append(devices, BluetoothDevice{
+				Name: name,
+				MAC:  port, // On Windows, we use COM port as identifier
+			})
+		}
+	}
+
+	// If no BT-specific ports found, list all COM ports
+	if len(devices) == 0 {
+		ports, _ := ListSerialPorts()
+		for _, port := range ports {
+			devices = append(devices, BluetoothDevice{
+				Name: port,
+				MAC:  port,
+			})
+		}
+	}
+
+	return devices, nil
+}
+
+// getBluetoothCOMPorts reads Bluetooth COM port mappings from registry
+func getBluetoothCOMPorts() (map[string]string, error) {
+	ports := make(map[string]string)
+
+	// Try to read from SERIALCOMM registry key
+	key, err := registry.OpenKey(registry.LOCAL_MACHINE, `HARDWARE\DEVICEMAP\SERIALCOMM`, registry.READ)
+	if err != nil {
+		return nil, err
+	}
+	defer key.Close()
+
+	names, err := key.ReadValueNames(-1)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, name := range names {
+		val, _, err := key.GetStringValue(name)
+		if err == nil {
+			// Check if it looks like a Bluetooth port
+			if strings.Contains(strings.ToLower(name), "bth") ||
+				strings.Contains(strings.ToLower(name), "bluetooth") {
+				ports[name] = val
+			}
+		}
+	}
+
+	return ports, nil
+}
+
+// CheckRFCOMMInstalled always returns nil on Windows (not needed)
+func CheckRFCOMMInstalled() error {
+	return nil
+}
+
+// CheckPrivilegeHelper always returns "windows" on Windows (no elevation needed for COM)
+func CheckPrivilegeHelper() string {
+	return "windows"
+}
+
+// EstablishRFCOMM on Windows simply returns the COM port path
+// Windows handles BT SPP as regular COM ports, no special setup needed
+func EstablishRFCOMM(mac string, channel int, statusCallback func(string)) (*RFCOMMConnection, error) {
+	// On Windows, 'mac' is actually the COM port (e.g., "COM3")
+	if statusCallback != nil {
+		statusCallback(fmt.Sprintf("Using port %s...", mac))
+	}
+
+	// Verify the port exists
+	comPath := mac
+	if !strings.HasPrefix(strings.ToUpper(mac), "COM") {
+		return nil, fmt.Errorf("invalid COM port: %s", mac)
+	}
+
+	// For COM ports > 9, need to use \\.\COM10 format
+	if len(mac) > 4 {
+		comPath = `\\.\` + mac
+	}
+
+	conn := &RFCOMMConnection{
+		DevicePath: comPath,
+		MAC:        mac,
+	}
+
+	if statusCallback != nil {
+		statusCallback(fmt.Sprintf("Ready: %s", mac))
+	}
+
+	return conn, nil
+}
+
+// Close is a no-op on Windows (COM ports don't need special cleanup)
+func (c *RFCOMMConnection) Close() error {
+	return nil
+}
+
+// IsDeviceReady checks if the COM port exists
+func (c *RFCOMMConnection) IsDeviceReady() bool {
+	if c.DevicePath == "" {
+		return false
+	}
+	// On Windows, we can't easily check if a COM port is available
+	// without trying to open it, so we just return true
+	return true
+}
+
+// GetExistingRFCOMMConnections returns available COM ports on Windows
+func GetExistingRFCOMMConnections() ([]string, error) {
+	return ListSerialPorts()
+}
+
+// ListSerialPorts enumerates available COM ports on Windows
+func ListSerialPorts() ([]string, error) {
+	var ports []string
+
+	// Read from registry
+	key, err := registry.OpenKey(registry.LOCAL_MACHINE, `HARDWARE\DEVICEMAP\SERIALCOMM`, registry.READ)
+	if err != nil {
+		// Fallback: check common COM ports
+		for i := 1; i <= 20; i++ {
+			port := fmt.Sprintf("COM%d", i)
+			// Try to check if port exists (this is a rough check)
+			ports = append(ports, port)
+		}
+		return ports[:4], nil // Return first 4 as fallback
+	}
+	defer key.Close()
+
+	names, err := key.ReadValueNames(-1)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, name := range names {
+		val, _, err := key.GetStringValue(name)
+		if err == nil {
+			ports = append(ports, val)
+		}
+	}
+
+	return ports, nil
+}
+
+// FindAvailableRFCOMMDevice is not needed on Windows but provided for compatibility
+func FindAvailableRFCOMMDevice() (string, int, error) {
+	ports, err := ListSerialPorts()
+	if err != nil || len(ports) == 0 {
+		return "", -1, fmt.Errorf("no COM ports found")
+	}
+	return ports[0], 0, nil
+}


### PR DESCRIPTION
Cross-platform Bluetooth handling:
- bluetooth.go: Shared types and errors
- bluetooth_linux.go: Linux-specific rfcomm/bluetoothctl implementation
- bluetooth_windows.go: Windows COM port enumeration via registry

Build system:
- make build-windows: Cross-compile for Windows from Linux
- make build-all: Build both platforms
- make install-cross-deps: Install mingw-w64 for cross-compilation

On Windows, paired Bluetooth SPP devices appear as COM ports automatically - no special rfcomm setup needed.

Updated README with:
- Platform support table
- Windows-specific instructions
- Cross-compilation guide
- Windows troubleshooting tips